### PR TITLE
Streamline Dockerfile and update readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,40 @@
-FROM python:3.8-buster
+FROM python:3.8-slim-buster
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
 # set a directory for the app
 WORKDIR /usr/src/app
 
-# copy all the files to the container
-COPY . .
-
 # install dependencies
-RUN apt update && apt install -y python3-venv apache2 apache2-dev libxslt1-dev libxml2-dev python-libxml2 python3-dev python-setuptools unixodbc-dev python3-pip
-# install dependencies for PostGRESQL DB
-# RUN apt install -y libpq-dev postgresql postgresql-contrib
-RUN mv opal/local_settings.py.docker opal/local_settings.py
-RUN pip3 install -r requirements.txt
-RUN touch db.sqlite3
-RUN python3 manage.py makemigrations
-RUN python3 manage.py migrate
-RUN python3 manage.py loaddata admin_user.json fixture_information_type.json fixture_status.json fixture_user_function.json fixture_user_privilege.json fixture_user_role.json
-RUN python3 manage.py collectstatic --noinput
-RUN chown -R www-data:www-data *
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3-venv libxslt1-dev libxml2-dev python-libxml2 python3-dev python-setuptools unixodbc-dev \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
+# install dependencies for PostGRESQL DB
+# RUN apt-get install -y --no-install-recommends libpq-dev postgresql postgresql-contrib && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# install Python requirements
+COPY requirements.txt /usr/src/app/
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# copy all the files to the container
+COPY . /usr/src/app/
+
+RUN mv opal/local_settings.py.docker opal/local_settings.py \
+  && touch db.sqlite3 \
+  && python3 manage.py makemigrations \
+  && python3 manage.py migrate \
+  && python3 manage.py loaddata admin_user.json fixture_information_type.json fixture_status.json fixture_user_function.json fixture_user_privilege.json fixture_user_role.json \
+  && python3 manage.py collectstatic --noinput \
+  && chown -R www-data:www-data .
+
+# run as an unprivileged user
+USER www-data
+
+# use -p 8000:8000 with `docker run` to access the service
 EXPOSE 8000
 
-CMD python3 manage.py runserver
+ENTRYPOINT [ "python", "manage.py" ]
+CMD ["runserver", "0.0.0.0:8000"]

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,11 @@
 # OSCAL Policy Administation Library (opal)
+
 Provides a simple web application for managing System Security Plans.  The data modle is based on the OSCAL standard. 
-# Deployment Instructions
-## Clone and configure the app
+
+## Deployment Instructions
+
+### Clone and configure the app
+
 1. Clone the repository to your local directory\
    `git clone https://gitlab.max.gov/max-security/opal.git`
 1. Install some required packages\
@@ -27,7 +31,7 @@ Provides a simple web application for managing System Security Plans.  The data 
 1. Build the image\
     `docker build -t opal:opal .`
 1. Run the container\
-    `docker run -p 8000:8000`
+    `docker run --rm -it --name opal -p 8000:8000 opal:opal`
     
 Note: A default superuser account is created in the docker container. You should immedietly change the password and create additional secure superuser accounts.
 


### PR DESCRIPTION
The Dockerfile was updated so that it...

1. builds smaller images (~1.2GB => 0.56GB)
2. caches apt and pip layers for faster rebuilds
3. uses a non-privileged user to run Django
4. removes apt and pip caches after adding files
5. tweaks the ENTRYPOINT and CMD to play nicer with Django

This relates to issue #5 